### PR TITLE
Update to @arv's main Traceur instead of the node-traceur fork.

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var nodeTraceur        =  require('node-traceur')
-  , traceur            =  nodeTraceur.traceur
+var traceur            =  require('traceur')
   , compile            =  traceur.codegeneration.Compiler.compile
   , SourceMapGenerator =  traceur.outputgeneration.SourceMapGenerator
   , Project            =  traceur.semantics.symbols.Project
@@ -43,12 +42,12 @@ module.exports = function compileFile(file, contents) {
     reportError : function(pos, msg) {
       err = format('%s:%s:%s %s', file, pos.line + 1, pos.offset, msg);
     },
-    hadError : function () { return !!err; } 
+    hadError : function () { return !!err; }
   };
 
   project.addFile(sourceFile);
 
-  var compiled = compile(reporter, project, false); 
+  var compiled = compile(reporter, project, false);
 
   if (err) return { source: null, sourcemap: null, error: err };
 

--- a/index.js
+++ b/index.js
@@ -44,10 +44,10 @@ function es6ify(filePattern, stderr) {
 
   return function (file) {
     if (!filePattern.test(file)) return through();
-    
+
     var data = '';
     return through(write, end);
-    
+
     function write (buf) { data += buf; }
     function end () {
       var hash = getHash(data)
@@ -55,7 +55,7 @@ function es6ify(filePattern, stderr) {
 
       if (!cached || cached.hash !== hash) {
         cache[file] = { compiled: compileFile(file, data, stderr), hash: hash };
-      }   
+      }
 
       this.queue(cache[file].compiled);
       this.queue(null);
@@ -65,4 +65,4 @@ function es6ify(filePattern, stderr) {
 
 module.exports           =  es6ify();
 module.exports.configure =  es6ify;
-module.exports.runtime   =  require('node-traceur').runtimePath;
+module.exports.runtime   =  require.resolve('traceur/src/runtime/runtime.js');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "convert-source-map": "~0.2.5",
     "through": "~2.2.7",
-    "node-traceur": "~0.1.2"
+    "traceur": "~0.0.3"
   },
   "devDependencies": {
     "browserify": "~2.7.2",

--- a/test/transform.js
+++ b/test/transform.js
@@ -29,12 +29,12 @@ test('transform adds sourcemap comment and uses cache on second time', function 
     fs.createReadStream(file)
         .pipe(es6ify(file))
         .pipe(through(write));
-    
+
     // second time
     fs.createReadStream(file)
         .pipe(es6ify(file))
         .pipe(through(write, end));
-    
+
     function write (buf) { data += buf; }
     function end () {
       var sourceMap = convert.fromSource(data).toObject();
@@ -45,7 +45,7 @@ test('transform adds sourcemap comment and uses cache on second time', function 
             file: file + '.es6',
             sources: [ file ],
             names: [],
-            mappings: 'AAAA,MAAA,CAAA,OAAA,EAAiB,SAAA,CAAU;;ACEf,cAAoB,QAAA,CAAA,OAAA,CAAA,WAA2B,CDDrC,CAAC,CAAA,CAAG,EAAA,CAAG,EAAA,CAAA,CAAA;ACErB;AACE,WAAA,EAAO,IAAA;;;;;ADHgB;AAC7B,mBAAA,CAAA,GAAW,CAAC,UAAA,CAAY,QAAA,CAAA;AAAA;AAAA;AAAA;AAAA,KCMlB,MAAA,EAAM,CAAA,CAAG;AACT,QAAA,EAAI,CAAC,OAAA,CAAA,OAAA,CAAA,eAA+B,CAAC,CAAA,CAAA,CACnC,MAAM,EAAA;AAAA;AAAA;AAAA,CAAA',
+            mappings: 'AAAA,MAAA,CAAA,OAAA,EAAiB,SAAA,CAAU;;ACEf,0CAAiD,CDDvC,CAAC,CAAA,CAAG,EAAA,CAAG,EAAA,CAAA,CAAA;ACErB;AACE,WAAA,EAAO,IAAA;;;;;ADHgB;AAC7B,mBAAA,CAAA,GAAW,CAAC,UAAA,CAAY,QAAA,CAAA;AAAA;AAAA;AAAA;AAAA,KCMlB,MAAA,EAAM,CAAA,CAAG;AACT,QAAA,EAAI,gCAAkC,CAAC,CAAA,CAAA,CACrC,MAAM,EAAA;AAAA;AAAA;AAAA,CAAA',
             sourcesContent: [ 'module.exports = function () {\n  for (let element of [1, 2, 3]) {\n    console.log(\'element:\', element);\n  }\n};\n' ] }
         , 'adds sourcemap comment including original source'
       );


### PR DESCRIPTION
Works great! Would suggest adding a deprecation notice to node-traceur's readme and doing `npm deprecate` on it.
