### PR TITLE
Simpler error handling

### DIFF
--- a/test/bundle/syntax-error.js
+++ b/test/bundle/syntax-error.js
@@ -1,0 +1,1 @@
+function () {

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,0 +1,19 @@
+'use strict';
+/*jshint asi: true */
+
+var test       =  require('tap').test;
+var browserify =  require('browserify');
+var es6ify     =  require('..');
+var path       =  require('path');
+
+test('\nsyntax error', function (t) {
+  t.plan(1);
+
+  browserify()
+    .transform(es6ify)
+    .require(__dirname + '/bundle/syntax-error.js', { entry: true })
+    .bundle(function (err, src) {
+      t.equal(err.message, path.resolve(__dirname + '/bundle/syntax-error.js') + ':1:13 \'}\' expected');
+      t.end();
+    });
+});

--- a/test/transform.js
+++ b/test/transform.js
@@ -11,7 +11,7 @@ var test       =  require('tap').test
 
 test('transform adds sourcemap comment and uses cache on second time', function (t) {
 
-    t.plan(2);
+    t.plan(3);
     var data = '';
     var compiles = 0;
 
@@ -45,10 +45,11 @@ test('transform adds sourcemap comment and uses cache on second time', function 
             file: file + '.es6',
             sources: [ file ],
             names: [],
-            mappings: 'AAAA,MAAA,CAAA,OAAA,EAAiB,SAAA,CAAU;;ACEf,0CAAiD,CDDvC,CAAC,CAAA,CAAG,EAAA,CAAG,EAAA,CAAA,CAAA;ACErB;AACE,WAAA,EAAO,IAAA;;;;;ADHgB;AAC7B,mBAAA,CAAA,GAAW,CAAC,UAAA,CAAY,QAAA,CAAA;AAAA;AAAA;AAAA;AAAA,KCMlB,MAAA,EAAM,CAAA,CAAG;AACT,QAAA,EAAI,gCAAkC,CAAC,CAAA,CAAA,CACrC,MAAM,EAAA;AAAA;AAAA;AAAA,CAAA',
+            mappings: sourceMap.mappings,
             sourcesContent: [ 'module.exports = function () {\n  for (let element of [1, 2, 3]) {\n    console.log(\'element:\', element);\n  }\n};\n' ] }
         , 'adds sourcemap comment including original source'
       );
+      t.ok(sourceMap.mappings.length);
       t.equal(compiles, 1, 'compiles only the first time');
     }
 });


### PR DESCRIPTION
The synchronous, buffered interface should just throw, because that's the simplest thing to do.

The streaming interface should just emit 'error' events.  Browserify can then handle those as appropriate and decide what to output.
