### PR TITLE
Expose `compileFile` as a public API method

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,3 +66,4 @@ function es6ify(filePattern, stderr) {
 module.exports           =  es6ify();
 module.exports.configure =  es6ify;
 module.exports.runtime   =  require.resolve('traceur/src/runtime/runtime.js');
+module.exports.compileFile = compileFile;


### PR DESCRIPTION
This module is very useful for things way outside of browserify.  Outside of browserify, the streaming is usually a pain and unnecessary (given that it buffers anyway).  This exposes a synchronous, buffered API.
