### PR TITLE
Fix #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,13 @@
 'use strict';
 
-var convert =  require('convert-source-map')
-  , through =  require('through')
-  , compile =  require('./compile')
-  , crypto  =  require('crypto')
-  , cache   =  {};
+var SM          = require('source-map')
+  , SMConsumer  = SM.SourceMapConsumer
+  , SMGenerator = SM.SourceMapGenerator
+  , through     =  require('through')
+  , compile     =  require('./compile')
+  , crypto      =  require('crypto')
+  , path        =  require('path')
+  , cache       =  {};
 
 function getHash(data) {
   return crypto
@@ -18,15 +21,35 @@ function compileFile(file, src) {
   compiled = compile(file, src);
   if (compiled.error) throw new Error(compiled.error);
 
-  var comment = convert
-    .fromJSON(compiled.sourcemap)
-    // override sources that traceur adds i.e. in cases that require the runtime like generators it adds genratorWrap@runtime
-    // it also doesn't include the path in the source
-    .setProperty('sources', [ file ])
-    .setProperty('sourcesContent', [ src ])
-    .toComment();
+  var comment
+    , consumer = new SMConsumer(compiled.sourcemap)
+    , generator = new SMGenerator({file: file + '.es6'});
 
-  return compiled.source + '\n' + comment;
+  generator.setSourceContent(file, src);
+
+  consumer.eachMapping(function (mapping) {
+    // Ignore mappings that are not from our source file
+    if(mapping.source && path.basename(file) === mapping.source) {
+      generator.addMapping(
+        {
+          original: {
+            column: mapping.originalColumn
+          , line: mapping.originalLine
+          }
+        , generated: {
+            column: mapping.generatedColumn
+          , line: mapping.generatedLine
+          }
+        , source: file
+        , name: mapping.name
+        }
+      );
+    }
+  });
+
+  comment = new Buffer(generator.toString()).toString('base64');
+
+  return compiled.source + '\n//@ sourceMappingURL=data:application/json;base64,' + comment;
 }
 
 function es6ify(filePattern) {

--- a/package.json
+++ b/package.json
@@ -12,15 +12,16 @@
   },
   "homepage": "https://github.com/thlorenz/es6ify",
   "dependencies": {
-    "convert-source-map": "~0.2.5",
     "through": "~2.2.7",
+    "source-map": "0.1.x",
     "traceur": "~0.0.3"
   },
   "devDependencies": {
     "browserify": "~2.7.2",
     "mold-source-map": "~0.2.0",
     "tap": "~0.4.0",
-    "proxyquire": "~0.4.0"
+    "proxyquire": "~0.4.0",
+    "convert-source-map": "~0.2.6"
   },
   "keywords": [
     "traceur",

--- a/test/transform.js
+++ b/test/transform.js
@@ -38,7 +38,6 @@ test('transform adds sourcemap comment and uses cache on second time', function 
     function write (buf) { data += buf; }
     function end () {
       var sourceMap = convert.fromSource(data).toObject();
-
       t.deepEqual(
           sourceMap
         , { version: 3,


### PR DESCRIPTION
To fix this issue I used the `source-map` package as `convert-source-map` is ill-suited to the task of modifying the actual mappings.

I moved `convert-source-map` to the `devDependences` as it does do a good job of parsing out the source map from the js for our tests.
