### PR TITLE
ES6 module support

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function compileFile(file, src) {
 
   consumer.eachMapping(function (mapping) {
     // Ignore mappings that are not from our source file
-    if(mapping.source && path.basename(file) === mapping.source) {
+    if(mapping.source && file === mapping.source) {
       generator.addMapping(
         {
           original: {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "through": "~2.2.7",
     "source-map": "~0.1.29",
-    "traceur": "0.0.7"
+    "traceur": "0.0.9"
   },
   "devDependencies": {
     "mold-source-map": "~0.2.0",


### PR DESCRIPTION
Hi,

not sure if it's something you'd want to merge in, but this pull request adds support for ES6 modules, so you can use 'module ... from ...', 'import ... from ...' and 'export ...'. They all get converted in traceur to commonjs modules, and then they get used in the usual ways by browserify.

The change to index.js is something that should've probably been separate - the way the code was before, it'd only do proper sourcemaps if you ran browserify in the same directory as your ES6 files or so - not really sure why the previous version ever worked.
