### PR TITLE
Upgrade to latest traceur

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -14,7 +14,7 @@ var options = {
     forOf: true,
     generatorComprehension: true,
     generators: true,
-    modules: true,
+    modules: 'commonjs',
     numericLiterals: true,
     propertyMethods: true,
     propertyNameShorthand: true,

--- a/compile.js
+++ b/compile.js
@@ -6,7 +6,6 @@ module.exports = function compileFile(file, contents) {
 
     var result = compile(contents, { 
       modules: 'commonjs',
-      blockBinding: true,
       sourceMap: true,
       filename: file
     });

--- a/compile.js
+++ b/compile.js
@@ -1,35 +1,15 @@
 'use strict';
 
-var extend = require("util-extend");
 var compile = require("traceur").compile;
-
-var options = {
-    experimental: true,
-    arrayComprehension: true,
-    arrowFunctions: true,
-    classes: true,
-    computedPropertyNames: true,
-    defaultParameters: true,
-    destructuring: true,
-    forOf: true,
-    generatorComprehension: true,
-    generators: true,
-    modules: 'commonjs',
-    numericLiterals: true,
-    propertyMethods: true,
-    propertyNameShorthand: true,
-    restParameters: true,
-    spread: true,
-    templateLiterals: true,
-    blockBinding: true,
-    symbols: true,
-    deferredFunctions: true,
-    sourceMap: true
-};
 
 module.exports = function compileFile(file, contents) {
 
-    var result = compile(contents, extend(options, { filename: file }));
+    var result = compile(contents, { 
+      modules: 'commonjs',
+      blockBinding: true,
+      sourceMap: true,
+      filename: file
+    });
 
     if (result.errors.length) {
         return { source: null, sourcemap: null, error: result.errors[0] };

--- a/compile.js
+++ b/compile.js
@@ -6,6 +6,7 @@ module.exports = function compileFile(file, contents) {
 
     var result = compile(contents, { 
       modules: 'commonjs',
+      blockBinding: true,
       sourceMap: true,
       filename: file
     });

--- a/example/src/features/classes.js
+++ b/example/src/features/classes.js
@@ -1,0 +1,9 @@
+class Foo {
+    toString() {
+        console.log('An instance of Foo says hi from its .toString()!')
+    }
+}
+
+module.exports = function () {
+    console.log(new Foo().toString());
+};

--- a/example/src/features/classes.js
+++ b/example/src/features/classes.js
@@ -1,6 +1,6 @@
 class Foo {
     toString() {
-        console.log('An instance of Foo says hi from its .toString()!')
+        return 'An instance of Foo says hi from its .toString()!';
     }
 }
 

--- a/example/src/features/index.js
+++ b/example/src/features/index.js
@@ -1,6 +1,7 @@
 module.exports = {
     blockScope        :  require('./block-scope')
   , destructuring     :  require('./destructuring')
+  , classes           :  require('./classes')
   , generators        :  require('./generators')
   , iterators         :  require('./iterators')
   , defaultParameters :  require('./default-parameters')

--- a/example/src/main.js
+++ b/example/src/main.js
@@ -5,6 +5,7 @@ let {
     blockScope
   , destructuring
   , generators 
+  , classes
   , iterators
   , defaultParameters
   , restParameters
@@ -15,6 +16,7 @@ let {
 blockScope();
 destructuring();
 generators();
+classes();
 const monster = makeMonster(3, 4, 'cookie');
 
 console.log('I am the %s monster', monster.name);

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var SM          = require('source-map')
   , compile     =  require('./compile')
   , crypto      =  require('crypto')
   , path        =  require('path')
+  , runtime     =  require.resolve(require('traceur').RUNTIME_PATH)
   , cache       =  {};
 
 function getHash(data) {
@@ -56,6 +57,10 @@ function es6ify(filePattern) {
   filePattern =  filePattern || /\.js$/;
 
   return function (file) {
+
+    // Don't es6ify the traceur runtime
+    if (file === runtime) return through();
+
     if (!filePattern.test(file)) return through();
 
     var data = '';
@@ -83,5 +88,5 @@ function es6ify(filePattern) {
 
 module.exports             =  es6ify();
 module.exports.configure   =  es6ify;
-module.exports.runtime     =  require.resolve(require('traceur').RUNTIME_PATH);
+module.exports.runtime     =  runtime;
 module.exports.compileFile =  compileFile;

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function compileFile(file, src) {
 
   consumer.eachMapping(function (mapping) {
     // Ignore mappings that are not from our source file
-    if(mapping.source && path.basename(file) === mapping.source) {
+    if(mapping.source && file === mapping.source) {
       generator.addMapping(
         {
           original: {
@@ -83,5 +83,5 @@ function es6ify(filePattern) {
 
 module.exports             =  es6ify();
 module.exports.configure   =  es6ify;
-module.exports.runtime     =  require.resolve('traceur/src/runtime/runtime.js');
+module.exports.runtime     =  require.resolve(require('traceur').RUNTIME_PATH);
 module.exports.compileFile =  compileFile;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "through": "~2.2.7",
     "source-map": "~0.1.29",
-    "traceur": "0.0.7"
+    "traceur": "0.0.30",
+    "util-extend": "^1.0.1"
   },
   "devDependencies": {
     "mold-source-map": "~0.2.0",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   "dependencies": {
     "through": "~2.2.7",
     "source-map": "~0.1.29",
-    "traceur": "0.0.31",
-    "util-extend": "^1.0.1"
+    "traceur": "0.0.31"
   },
   "devDependencies": {
     "mold-source-map": "~0.2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "through": "~2.2.7",
     "source-map": "~0.1.29",
-    "traceur": "0.0.30",
+    "traceur": "0.0.31",
     "util-extend": "^1.0.1"
   },
   "devDependencies": {

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -8,14 +8,12 @@ var es6ify     =  require('..');
 var format     =  require('util').format;
 
 [ [ 'run-destructuring'     , [ 'hello, world' ] ]
-, [ 'run-block-scope'       , [ 'tmp is undefined:  true' ] ]
 , [ 'run-classes'       , [ 'An instance of Foo says hi from its .toString()!' ] ]
 , [ 'run-default-parameters', [ 'name: Bruno, codes: JavaScript, lives in: USA' ] ]
 , [ 'run-rest-parameters'   , ['list fruits has the following items', 'apple', 'banana' ] ]
 , [ 'run-spread-operator'       , [ '3 + 4 = 7' ] ]
 , [ 'run-combined', [
       'hello, world'
-    , 'tmp is undefined:  true'
     , 'An instance of Foo says hi from its .toString()!'
     , 'name: Bruno, codes: JavaScript, lives in: USA'
     , 'list fruits has the following items', 'apple', 'banana' 

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -7,9 +7,6 @@ var vm         =  require('vm');
 var es6ify     =  require('..');
 var format     =  require('util').format;
 
-// Adds $traceurRuntime to globals
-require(es6ify.runtime);
-
 [ [ 'run-destructuring'     , [ 'hello, world' ] ]
 , [ 'run-block-scope'       , [ 'tmp is undefined:  true' ] ]
 , [ 'run-classes'       , [ 'An instance of Foo says hi from its .toString()!' ] ]
@@ -32,14 +29,16 @@ require(es6ify.runtime);
 
   test('\nbundle with runtime - ' + filename, function (t) {
     t.plan(expectedLogs.length)
-      browserify()
+      
+    browserify()
+      .add(es6ify.runtime)
       .transform(es6ify)
       .require(__dirname + '/bundle/' + filename + '.js', { entry: true })
       .bundle(function (err, src) {
         if (err) t.fail(err);
+        src = 'window=this;'+src;
         vm.runInNewContext(src, {
-            $traceurRuntime: $traceurRuntime,
-            window: {},
+            window: {}, 
             console: { log: log }
         });
         t.end()

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -8,12 +8,14 @@ var es6ify     =  require('..');
 var format     =  require('util').format;
 
 [ [ 'run-destructuring'     , [ 'hello, world' ] ]
+, [ 'run-block-scope'       , [ 'tmp is undefined:  true' ] ]
 , [ 'run-classes'       , [ 'An instance of Foo says hi from its .toString()!' ] ]
 , [ 'run-default-parameters', [ 'name: Bruno, codes: JavaScript, lives in: USA' ] ]
 , [ 'run-rest-parameters'   , ['list fruits has the following items', 'apple', 'banana' ] ]
 , [ 'run-spread-operator'       , [ '3 + 4 = 7' ] ]
 , [ 'run-combined', [
       'hello, world'
+    , 'tmp is undefined:  true'
     , 'An instance of Foo says hi from its .toString()!'
     , 'name: Bruno, codes: JavaScript, lives in: USA'
     , 'list fruits has the following items', 'apple', 'banana' 

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -7,15 +7,19 @@ var vm         =  require('vm');
 var es6ify     =  require('..');
 var format     =  require('util').format;
 
+// Adds $traceurRuntime to globals
+require(es6ify.runtime);
+
 [ [ 'run-destructuring'     , [ 'hello, world' ] ]
-, [ 'run-classes'       , [ 'An instance of Foo says hi from its .toString()!' ] ]
 , [ 'run-block-scope'       , [ 'tmp is undefined:  true' ] ]
+, [ 'run-classes'       , [ 'An instance of Foo says hi from its .toString()!' ] ]
 , [ 'run-default-parameters', [ 'name: Bruno, codes: JavaScript, lives in: USA' ] ]
 , [ 'run-rest-parameters'   , ['list fruits has the following items', 'apple', 'banana' ] ]
 , [ 'run-spread-operator'       , [ '3 + 4 = 7' ] ]
 , [ 'run-combined', [
       'hello, world'
     , 'tmp is undefined:  true'
+    , 'An instance of Foo says hi from its .toString()!'
     , 'name: Bruno, codes: JavaScript, lives in: USA'
     , 'list fruits has the following items', 'apple', 'banana' 
     , '3 + 4 = 7'
@@ -26,15 +30,15 @@ var format     =  require('util').format;
   var filename     =  row[0];
   var expectedLogs =  row[1];
 
-  test('\nbundle without runtime - ' + filename, function (t) {
+  test('\nbundle with runtime - ' + filename, function (t) {
     t.plan(expectedLogs.length)
-      
-    browserify()
+      browserify()
       .transform(es6ify)
       .require(__dirname + '/bundle/' + filename + '.js', { entry: true })
       .bundle(function (err, src) {
         if (err) t.fail(err);
         vm.runInNewContext(src, {
+            $traceurRuntime: $traceurRuntime,
             window: {},
             console: { log: log }
         });

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -8,6 +8,7 @@ var es6ify     =  require('..');
 var format     =  require('util').format;
 
 [ [ 'run-destructuring'     , [ 'hello, world' ] ]
+, [ 'run-classes'       , [ 'An instance of Foo says hi from its .toString()!' ] ]
 , [ 'run-block-scope'       , [ 'tmp is undefined:  true' ] ]
 , [ 'run-default-parameters', [ 'name: Bruno, codes: JavaScript, lives in: USA' ] ]
 , [ 'run-rest-parameters'   , ['list fruits has the following items', 'apple', 'banana' ] ]
@@ -34,7 +35,7 @@ var format     =  require('util').format;
       .bundle(function (err, src) {
         if (err) t.fail(err);
         vm.runInNewContext(src, {
-            window: {}, 
+            window: {},
             console: { log: log }
         });
         t.end()

--- a/test/bundle/run-block-scope.js
+++ b/test/bundle/run-block-scope.js
@@ -1,0 +1,1 @@
+require('../../example/src/features/block-scope')();

--- a/test/bundle/run-block-scope.js
+++ b/test/bundle/run-block-scope.js
@@ -1,1 +1,0 @@
-require('../../example/src/features/block-scope')();

--- a/test/bundle/run-classes.js
+++ b/test/bundle/run-classes.js
@@ -1,0 +1,1 @@
+require('../../example/src/features/classes')();

--- a/test/bundle/run-combined.js
+++ b/test/bundle/run-combined.js
@@ -1,5 +1,4 @@
 require('./run-destructuring');
-require('./run-block-scope');
 require('./run-classes');
 require('./run-default-parameters');
 require('./run-rest-parameters');

--- a/test/bundle/run-combined.js
+++ b/test/bundle/run-combined.js
@@ -1,6 +1,6 @@
 require('./run-destructuring');
-require('./run-classes');
 require('./run-block-scope');
+require('./run-classes');
 require('./run-default-parameters');
 require('./run-rest-parameters');
 require('./run-spread-operator');

--- a/test/bundle/run-combined.js
+++ b/test/bundle/run-combined.js
@@ -1,4 +1,5 @@
 require('./run-destructuring');
+require('./run-classes');
 require('./run-block-scope');
 require('./run-default-parameters');
 require('./run-rest-parameters');

--- a/test/bundle/run-combined.js
+++ b/test/bundle/run-combined.js
@@ -1,4 +1,5 @@
 require('./run-destructuring');
+require('./run-block-scope');
 require('./run-classes');
 require('./run-default-parameters');
 require('./run-rest-parameters');

--- a/test/errors.js
+++ b/test/errors.js
@@ -13,7 +13,7 @@ test('\nsyntax error', function (t) {
     .transform(es6ify)
     .require(__dirname + '/bundle/syntax-error.js', { entry: true })
     .bundle(function (err, src) {
-      t.equal(err.message, path.resolve(__dirname + '/bundle/syntax-error.js') + ':1:13 \'}\' expected');
+      t.equal(err.message, path.resolve(__dirname + '/bundle/syntax-error.js') + ':1:10: \'identifier\' expected');
       t.end();
     });
 });


### PR DESCRIPTION
Fixes #16

This is basically a rewrite of ./compile.js that instead delegates to traceur's own compile function, plus a few test tweaks to make it pass. Since more of the ES6 features now requires the $traceurRuntime global to be included in the bundle to work, I've just included it in all bundles generated in `./test/bundle.js`. We could split this in two different tests, one that runs examples that requires the runtime, and one that runs examples that can live without the runtime. Not sure if it is really important though.

My goal here was to make as few changes as possible to and still make the test suite pass with an up-to-date traceur, I haven't really thought too much about the configuration options passed on to the compiler, like `{modules: 'commonjs'}` etc.

It would be nice to have tests for more of the es6 features enabled by the updated traceur, I've included one for class syntax, guess the rest is up for grabs.
