### PR TITLE
Moved es6 examples into readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,45 +328,166 @@ your production bundle.
 
 ### arrayComprehension
 
+```js
+[for (i of [1, 2, 3]) i * i]; // [1, 4, 9]
+[for (x of 'abcdefgh'.split('')) for (y of '12345678'.split('')) (x+y)];
+```
+
 ### arrowFunctions
 
-[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/arrow-functions.js)
+```js
+var log = msg => console.log(msg);
+```
 
 ### classes
 
-[example](https://github.com/thlorenz/es6ify/blob/master/example/src/make-monster.js)
+```js
+class Character {
+  constructor(x, y, name) {
+    this.x = x;
+    this.y = y;
+  }
+  attack(character) {
+    console.log('attacking', character);
+  }
+}
+
+class Monster extends Character {
+  constructor(x, y, name) {
+    super(x, y);
+    this.name = name;
+    this.health_ = 100;
+  }
+
+  attack(character) {
+    super.attack(character);
+  }
+
+  get isAlive() { return this.health > 0; }
+  get health() { return this.health_; }
+  set health(value) {
+    if (value < 0) throw new Error('Health must be non-negative.');
+    this.health_ = value;
+  }
+}
+```
 
 ### defaultParameters
 
-[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/default-parameters.js)
+```js
+function logDeveloper(name, codes = 'JavaScript', livesIn = 'USA') {
+  console.log('name: %s, codes: %s, lives in: %s', name, codes, livesIn);
+};
+```
 
 ### destructuring
 
-[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/destructuring.js)
+```js
+var [a, [b], c, d] = ['hello', [', ', 'junk'], ['world']];
+console.log(a + b + c); // hello world
+```
 
 ### forOf
 
-[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/iterators.js)
+```js
+for (let element of [1, 2, 3]) {
+  console.log('element:', element);
+}
+```
 
 ### propertyMethods
 
+```js
+var object = {
+  prop: 42,
+  // No need for function
+  method() {
+    return this.prop;
+  }
+};
+```
+
 ### propertyNameShorthand
+
+? not sure which this is ~pfraze
 
 ### templateLiterals
 
+```js
+var x = 5, y = 10;
+console.log(`${x} + ${y} = ${ x + y}`)
+// 5 + 10 = 15
+```
+
 ### restParameters
 
-[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/rest-parameters.js)
+```js
+function printList(listname, ...items) {
+  console.log('list %s has the following items', listname);
+  items.forEach(function (item) { console.log(item); });
+};
+```
 
 ### spread
 
-[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/spread-operator.js)
+```js
+function add(x, y) {
+  console.log('%d + %d = %d', x, y, x + y);
+}
+var numbers = [5, 10]
+add(...numbers);
+// 5 + 10 = 15
+};
+```
 
 ### generatorComprehension
 
+double check this ~pfraze
+
+```js
+function* numberlist() {
+  yield 1;
+  yield 2;
+  yield 3;
+}
+(for (i of numberlist) i * i); // [1, 4, 9]
+```
+
 ### generators
 
-[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/generators.js)
+```js
+// A binary tree class.
+function Tree(left, label, right) {
+  this.left = left;
+  this.label = label;
+  this.right = right;
+}
+
+// A recursive generator that iterates the Tree labels in-order.
+function* inorder(t) {
+  if (t) {
+    yield* inorder(t.left);
+    yield t.label;
+    yield* inorder(t.right);
+  }
+}
+
+// Make a tree
+function make(array) {
+  // Leaf node:
+  if (array.length == 1) return new Tree(null, array[0], null);
+  return new Tree(make(array[0]), array[1], make(array[2]));
+}
+
+
+let tree = make([[['a'], 'b', ['c']], 'd', [['e'], 'f', ['g']]]);
+console.log('generating tree labels in order:');
+
+// Iterate over it
+for (let node of inorder(tree)) {
+  console.log(node); // a, b, c, d, ...
+}
+```
 
 ### modules 
 
@@ -377,7 +498,17 @@ with browserify.
 
 ### block scope (`let`)
 
-[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/block-scope.js)
+```js
+unction () {
+  var a = 2, b = 3;
+  { // new block
+    let tmp = a;
+    a = b;
+    b = tmp;
+  }
+  console.log('tmp is undefined: ', typeof tmp == 'undefined');
+}
+```
 
 The block binding `let` is implemented in ES5 via `try/catch` blocks which may affect performance.
 

--- a/README.md
+++ b/README.md
@@ -335,11 +335,15 @@ your production bundle.
 
 ### arrowFunctions
 
+[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/arrow-functions.js)
+
 ```js
 var log = msg => console.log(msg);
 ```
 
 ### classes
+
+[example](https://github.com/thlorenz/es6ify/blob/master/example/src/make-monster.js)
 
 ```js
 class Character {
@@ -374,6 +378,8 @@ class Monster extends Character {
 
 ### defaultParameters
 
+[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/default-parameters.js)
+
 ```js
 function logDeveloper(name, codes = 'JavaScript', livesIn = 'USA') {
   console.log('name: %s, codes: %s, lives in: %s', name, codes, livesIn);
@@ -382,12 +388,16 @@ function logDeveloper(name, codes = 'JavaScript', livesIn = 'USA') {
 
 ### destructuring
 
+[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/destructuring.js)
+
 ```js
 var [a, [b], c, d] = ['hello', [', ', 'junk'], ['world']];
 console.log(a + b + c); // hello world
 ```
 
 ### forOf
+
+[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/iterators.js)
 
 ```js
 for (let element of [1, 2, 3]) {
@@ -409,8 +419,6 @@ var object = {
 
 ### propertyNameShorthand
 
-? not sure which this is ~pfraze
-
 ### templateLiterals
 
 ```js
@@ -421,6 +429,8 @@ console.log(`${x} + ${y} = ${ x + y}`)
 
 ### restParameters
 
+[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/rest-parameters.js)
+
 ```js
 function printList(listname, ...items) {
   console.log('list %s has the following items', listname);
@@ -429,6 +439,8 @@ function printList(listname, ...items) {
 ```
 
 ### spread
+
+[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/spread-operator.js)
 
 ```js
 function add(x, y) {
@@ -442,8 +454,6 @@ add(...numbers);
 
 ### generatorComprehension
 
-double check this ~pfraze
-
 ```js
 function* numberlist() {
   yield 1;
@@ -454,6 +464,8 @@ function* numberlist() {
 ```
 
 ### generators
+
+[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/generators.js)
 
 ```js
 // A binary tree class.
@@ -498,8 +510,10 @@ with browserify.
 
 ### block scope (`let`)
 
+[example](https://github.com/thlorenz/es6ify/blob/master/example/src/features/block-scope.js)
+
 ```js
-unction () {
+function () {
   var a = 2, b = 3;
   { // new block
     let tmp = a;


### PR DESCRIPTION
When I check out es6ify, I tend to look for code examples of what's supported. Since I'm not always sure what the es6 features are by name, it helps to have them written out for me.

I'd suggest the same for the gh-pages index.html. Alternatively, make the link to Traceur's readme (which has the examples listed) more prominent.
