### PR TITLE
Bump traceur

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es6ify",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "browserify v2 transform to compile JavaScript.next (ES6) to JavaScript.current (ES5) on the fly.",
   "main": "es6ify.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "source-map": "~0.1.29",
     "through": "~2.2.7",
-    "traceur": "0.0.32",
+    "traceur": "0.0.39",
     "xtend": "~2.2.0"
   },
   "devDependencies": {

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -37,7 +37,7 @@ var format     =  require('util').format;
       
     es6ify.traceurOverrides = overrides;
     var bfy = browserify();
-    if (useRuntime) bfy.add(es6ify.runtime);
+    bfy.add(es6ify.runtime);
 
     bfy
       .transform(es6ify)


### PR DESCRIPTION
Upgrade traceur to 0.39. This caused some of the tests to throw a `$traceurRuntime not defined` error which was fixed by including the runtime in all tests.
