### PR TITLE
Version bump traceur to 0.0.42.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "source-map": "~0.1.29",
     "through": "~2.2.7",
-    "traceur": "0.0.32",
+    "traceur": "0.0.42",
     "xtend": "~2.2.0"
   },
   "devDependencies": {

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -8,7 +8,7 @@ var es6ify     =  require('..');
 var compile    =  require('../compile');
 var format     =  require('util').format;
 
-[ [ 'run-destructuring'     , [ 'hello, world' ] ]
+[ [ 'run-destructuring'     , [ 'hello, world' ], true ]
 , [ 'run-block-scope'       , [ 'tmp is undefined:  true' ] , false, { blockBinding: true } ]
 , [ 'run-default-parameters', [ 'name: Bruno, codes: JavaScript, lives in: USA' ] ]
 , [ 'run-rest-parameters'   , ['list fruits has the following items', 'apple', 'banana' ] ]


### PR DESCRIPTION
destructuring now requires the runtime.

Other packages also updated to latest. `npm test` looking good! 
