### PR TITLE
chore(traceur): update to version 0.0.55

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -4,13 +4,19 @@ var compile = require('traceur').compile
   , xtend = require('xtend')
   ;
 
-var traceurOptions = { 
+var traceurOptions = {
   modules      : 'commonjs',
-  sourceMap    : true
-}
+  sourceMaps   : true
+};
 
 exports = module.exports = function compileFile(file, contents, traceurOverrides) {
   var options = xtend(traceurOptions, traceurOverrides, { filename: file });
+  if (typeof options.sourceMap !== 'undefined') {
+    console.warn('es6ify: DEPRECATED options.sourceMap has changed to options.sourceMaps (plural)');
+    options.sourceMaps = options.sourceMap;
+    delete options.sourceMap;
+  }
+
   var result = compile(contents, options);
 
   if (result.errors.length) {
@@ -19,6 +25,6 @@ exports = module.exports = function compileFile(file, contents, traceurOverrides
   return {
       source: result.js,
       errors: result.errors,
-      sourcemap: result.sourceMap ? JSON.parse(result.sourceMap) : null
+      sourcemap: result.generatedSourceMap ? JSON.parse(result.generatedSourceMap) : null
   };
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "source-map": "~0.1.29",
     "through": "~2.2.7",
-    "traceur": "0.0.42",
+    "traceur": "0.0.55",
     "xtend": "~2.2.0"
   },
   "devDependencies": {

--- a/test/errors.js
+++ b/test/errors.js
@@ -11,7 +11,7 @@ test('\nsyntax error', function (t) {
     .transform(es6ify)
     .require(__dirname + '/bundle/syntax-error.js', { entry: true })
     .bundle(function (err, src) {
-      t.equal(err.message, path.resolve(__dirname + '/bundle/syntax-error.js') + ':1:10: \'identifier\' expected');
+      t.equal(err.message, path.resolve(__dirname + '/bundle/syntax-error.js') + ':1:10: Unexpected token (');
       t.end();
     });
 })


### PR DESCRIPTION
Update traceur to 0.0.53

CHANGES:
- sourceMap property changed to plural `sourceMaps`
- sourceMap result from compiler is in the property named `generatedSourceMap`
- update error message for syntax error
