### PR TITLE
Add some info about add(es6ify.runtime) effects

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,6 +122,11 @@ exports.configure = es6ify;
  * The traceur runtime exposed here so it can be included in the bundle via:
  *
  * `browserify.add(es6ify.runtime)`
+ * 
+ * Adding the runtime as such, however, breaks the default behavior of Browserify: instead of
+ * applying transforms (including es6ify) only to the local package, it will apply them to
+ * all files in `node_modules`. This may break some packages, so it is recommended to use 
+ * `es6ify::configure` with `/^(?!.*node_modules)+.+\.js$/`.
  *
  * ### Note
  *


### PR DESCRIPTION
Adding `es6ify.runtime` to browserify unfortunately breaks the default behavior decribed on its [README](https://github.com/substack/node-browserify#btransformopts-tr), that is, applying transform only on the local package files. It took me a bit of time to understand why one of my submodules was getting broken once in the browser; it was simply because traceur adds "use strict" and it was not compatible.

The reason it changes browserify behavior is because it considers everything that is parent to the added file folder to be part of the local package.

So I suggest we make that fact explicit here. We may also want to talk about it in the first example (?)
