### PR TITLE
Update Traceur(0.0.61) and add Windows fixes

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var compile = require('traceur').compile
+var Compiler = require('traceur').NodeCompiler
   , xtend = require('xtend')
   ;
 
@@ -16,15 +16,22 @@ exports = module.exports = function compileFile(file, contents, traceurOverrides
     options.sourceMaps = options.sourceMap;
     delete options.sourceMap;
   }
+  try{
+    var compiler = new Compiler(options);
 
-  var result = compile(contents, options);
-
-  if (result.errors.length) {
-      return { source: null, sourcemap: null, error: result.errors[0] };
+    var result = compiler.compile(contents);
+    var sourceMap = compiler.getSourceMap();
+    var errors = null;
+  }catch(err){
+    errors = err;
+    if (errors.length) {
+      return { source: null, sourcemap: null, error: errors[0] };
+    }
   }
+
   return {
-      source: result.js,
-      errors: result.errors,
-      sourcemap: result.generatedSourceMap ? JSON.parse(result.generatedSourceMap) : null
+      source: result,
+      errors: errors,
+      sourcemap: sourceMap ? JSON.parse(sourceMap) : null
   };
 };

--- a/compile.js
+++ b/compile.js
@@ -10,7 +10,7 @@ var traceurOptions = {
 };
 
 exports = module.exports = function compileFile(file, contents, traceurOverrides) {
-  var options = xtend(traceurOptions, traceurOverrides, { filename: file });
+  var options = xtend(traceurOptions, traceurOverrides);
   if (typeof options.sourceMap !== 'undefined') {
     console.warn('es6ify: DEPRECATED options.sourceMap has changed to options.sourceMaps (plural)');
     options.sourceMaps = options.sourceMap;
@@ -19,7 +19,7 @@ exports = module.exports = function compileFile(file, contents, traceurOverrides
   try{
     var compiler = new Compiler(options);
 
-    var result = compiler.compile(contents);
+    var result = compiler.compile(contents, file);
     var sourceMap = compiler.getSourceMap();
   }catch(errors){
       return { source: null, sourcemap: null, error: errors[0] };

--- a/compile.js
+++ b/compile.js
@@ -21,17 +21,13 @@ exports = module.exports = function compileFile(file, contents, traceurOverrides
 
     var result = compiler.compile(contents);
     var sourceMap = compiler.getSourceMap();
-    var errors = null;
-  }catch(err){
-    errors = err;
-    if (errors.length) {
+  }catch(errors){
       return { source: null, sourcemap: null, error: errors[0] };
-    }
   }
 
   return {
       source: result,
-      errors: errors,
+      errors: null,
       sourcemap: sourceMap ? JSON.parse(sourceMap) : null
   };
 };

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ function compileFile(file, src) {
   generator.setSourceContent(file, src);
 
   consumer.eachMapping(function (mapping) {
+    mapping.source = path.normalize(mapping.source);
     // Ignore mappings that are not from our source file
     if(mapping.source && file === mapping.source) {
       generator.addMapping(

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "source-map": "~0.1.29",
     "through": "~2.2.7",
-    "traceur": "0.0.61",
+    "traceur": "0.0.62",
     "xtend": "~2.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "source-map": "~0.1.29",
     "through": "~2.2.7",
-    "traceur": "0.0.55",
+    "traceur": "0.0.61",
     "xtend": "~2.2.0"
   },
   "devDependencies": {

--- a/test/errors.js
+++ b/test/errors.js
@@ -11,7 +11,7 @@ test('\nsyntax error', function (t) {
     .transform(es6ify)
     .require(__dirname + '/bundle/syntax-error.js', { entry: true })
     .bundle(function (err, src) {
-      t.equal(err.message, path.normalize('bundle/syntax-error.js') + ':1:10: Unexpected token (');
+      t.equal(err.message, path.relative(__dirname, 'bundle/syntax-error.js') + ':1:10: Unexpected token (');
       t.end();
     });
 })

--- a/test/errors.js
+++ b/test/errors.js
@@ -11,7 +11,7 @@ test('\nsyntax error', function (t) {
     .transform(es6ify)
     .require(__dirname + '/bundle/syntax-error.js', { entry: true })
     .bundle(function (err, src) {
-      t.equal(err.message, path.resolve(__dirname + '/bundle/syntax-error.js') + ':1:10: Unexpected token (');
+      t.equal(err.message, path.normalize('bundle/syntax-error.js') + ':1:10: Unexpected token (');
       t.end();
     });
 })

--- a/test/transform.js
+++ b/test/transform.js
@@ -8,6 +8,7 @@ var test       =  require('tap').test
   , convert    =  require('convert-source-map')
   , compile    =  require('../compile')
   , proxyquire =  require('proxyquire')
+  , os         =  require('os');
 
 test('transform adds sourcemap comment and uses cache on second time', function (t) {
 
@@ -48,7 +49,7 @@ test('transform adds sourcemap comment and uses cache on second time', function 
             sources: [ file ],
             names: [],
             mappings: sourceMap.mappings,
-            sourcesContent: [ 'module.exports = function () {\n  for (let element of [1, 2, 3]) {\n    console.log(\'element:\', element);\n  }\n};\n' ] }
+            sourcesContent: [ 'module.exports = function () {' + os.EOL + '  for (let element of [1, 2, 3]) {' + os.EOL + '    console.log(\'element:\', element);' + os.EOL + '  }' + os.EOL + '};' + os.EOL + '' ] }
         , 'adds sourcemap comment including original source'
       );
       t.ok(sourceMap.mappings.length);


### PR DESCRIPTION
Hi, I updated Traceur to the last version (0.0.61) and fixed the sourcemaps and the tests for Windows users. :)
