### PR TITLE
IW: Protect against null source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,36 +31,39 @@ function compileFile(file, src) {
   compiled = compile(file, src, exports.traceurOverrides);
   if (compiled.error) throw new Error(compiled.error);
 
-  var comment
-    , consumer = new SMConsumer(compiled.sourcemap)
-    , generator = new SMGenerator({file: file + '.es6'});
+  if (compiled.sourcemap !== null) {
 
-  generator.setSourceContent(file, src);
+    var comment
+      , consumer = new SMConsumer(compiled.sourcemap)
+      , generator = new SMGenerator({file: file + '.es6'});
 
-  consumer.eachMapping(function (mapping) {
+    generator.setSourceContent(file, src);
+    consumer.eachMapping(function (mapping) {
     mapping.source = path.normalize(mapping.source);
     // Ignore mappings that are not from our source file
-    if(mapping.source && file === mapping.source) {
-      generator.addMapping(
-        {
-          original: {
-            column: mapping.originalColumn
-          , line: mapping.originalLine
+      if (mapping.source && file === mapping.source) {
+        generator.addMapping(
+          {
+            original: {
+              column: mapping.originalColumn
+            , line: mapping.originalLine
+            }
+          , generated: {
+              column: mapping.generatedColumn
+            , line: mapping.generatedLine
+            }
+          , source: file
+          , name: mapping.name
           }
-        , generated: {
-            column: mapping.generatedColumn
-          , line: mapping.generatedLine
-          }
-        , source: file
-        , name: mapping.name
-        }
-      );
-    }
-  });
+        );
+      }
+    });
 
-  comment = new Buffer(generator.toString()).toString('base64');
+    comment = new Buffer(generator.toString()).toString('base64');
 
-  return compiled.source + '\n//@ sourceMappingURL=data:application/json;base64,' + comment;
+    return compiled.source + '\n//@ sourceMappingURL=data:application/json;base64,' + comment;
+  }
+  return compiled.source;
 }
 
 function es6ify(filePattern) {


### PR DESCRIPTION
Please let me know if you guys would like a different solution to this issue. This is what 
seemed to work for us, but might be considered too much of a hack. 

There are situations where traceur will return null for the source map
property. For example, when using browserify's exclude flag, a temporary
but empty file is generated. es6ify will blow up on this file because it
always blindly assumes that there will be a sourcmap property. This
commit checks to see if the source map property exists before parsing
it. If there is no source map property, it just returns the source from
the compiled output.
