### PR TITLE
readme: remove bundle args

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 JavaScript.current (ES5) on the fly.
 
 ```js
-browserify()
+browserify({ debug: true })
   .add(es6ify.runtime)
   .transform(es6ify)
   .require(require.resolve('./src/main.js'), { entry: true })
-  .bundle({ debug: true })
+  .bundle()
   .pipe(fs.createWriteStream(bundlePath));
 ```
 
@@ -278,12 +278,12 @@ By configuring the regex to exclude ES5 files, you can optimize the performance 
 ES5 JavaScript will work since it is a subset of ES6.
 
 ```js
-browserify()
+browserify({ debug: true })
   .add(require('es6ify').runtime)
    // compile all .js files except the ones coming from node_modules
   .transform(require('es6ify').configure(/^(?!.*node_modules)+.+\.js$/))
   .require(require.resolve('./src/main.js'), { entry: true })
-  .bundle({ debug: true })
+  .bundle()
   .pipe(fs.createWriteStream(bundlePath));
 ```
 
@@ -298,10 +298,10 @@ For instance to support the async functions (`async`/`await`) feature you'd do t
 ```js
 var es6ify = require('es6ify');
 es6ify.traceurOverrides = { asyncFunctions: true };
-browserify()
+browserify({ debug: true })
   .add(es6ify.runtime)
   .require(require.resolve('./src/main.js'), { entry: true })
-  .bundle({ debug: true })
+  .bundle()
   .pipe(fs.createWriteStream(bundlePath));
 ```
 

--- a/example/build.js
+++ b/example/build.js
@@ -8,11 +8,11 @@ var path       = require('path')
   , bundlePath = path.join(jsRoot, 'bundle.js')
   ;
 
-browserify()
+browserify({ debug: true })
   .add(es6ify.runtime)
   .transform(es6ify)
   .require(require.resolve('./src/main.js'), { entry: true })
-  .bundle({ debug: true })
+  .bundle()
   .on('error', function (err) { console.error(err); })
   .pipe(fs.createWriteStream(bundlePath));
 


### PR DESCRIPTION
When copying this code over `browserify` throws an error stating that `.bundle(opts)` is deprecated. This should fix that. Thanks!
