### PR TITLE
Package config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,25 +31,33 @@ Find the full version of this example [here](https://github.com/thlorenz/es6ify/
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
 - [Enabling sourcemaps and related posts](#enabling-sourcemaps-and-related-posts)
+- [Configuration](#configuration)
 - [API](#api)
+    - [e6ify::runtime](#e6ifyruntime)
+    - [es6ify() → {function}](#es6ify-→-function)
+    - [es6ify::traceurOverrides](#es6ifytraceuroverrides)
+    - [Example](#example)
+    - [es6ify::compileFile(file, src) → {string}](#es6ifycompilefilefile-src-→-string)
+    - [es6ify::configure(filePattern) → {function}](#es6ifyconfigurefilepattern-→-function)
 - [Examples](#examples)
-	- [es6ify.configure(filePattern : Regex)](#es6ifyconfigurefilepattern--regex)
-	- [es6ify.traceurOverrides](#es6ifytraceuroverrides)
+  - [es6ify.configure(filePattern : Regex)](#es6ifyconfigurefilepattern--regex)
+  - [es6ify.traceurOverrides](#es6ifytraceuroverrides)
 - [Caching](#caching)
 - [Source Maps](#source-maps)
 - [Supported ES6 features](#supported-es6-features)
-	- [arrowFunctions](#arrowfunctions)
-	- [classes](#classes)
-	- [defaultParameters](#defaultparameters)
-	- [destructuring](#destructuring)
-	- [forOf](#forof)
-	- [propertyMethods](#propertymethods)
-	- [propertyNameShorthand](#propertynameshorthand)
-	- [templateLiterals](#templateliterals)
-	- [restParameters](#restparameters)
-	- [spread](#spread)
-	- [generators](#generators)
-	- [modules](#modules)
+  - [arrowFunctions](#arrowfunctions)
+  - [classes](#classes)
+  - [defaultParameters](#defaultparameters)
+  - [destructuring](#destructuring)
+  - [forOf](#forof)
+  - [propertyMethods](#propertymethods)
+  - [propertyNameShorthand](#propertynameshorthand)
+  - [templateLiterals](#templateliterals)
+  - [restParameters](#restparameters)
+  - [spread](#spread)
+  - [generators](#generators)
+  - [block scoping](#block-scoping)
+  - [modules](#modules)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -59,6 +67,26 @@ Find the full version of this example [here](https://github.com/thlorenz/es6ify/
 - In IE: works in IE11 onward by default
 - [browserify-sourcemaps](http://thlorenz.com/blog/browserify-sourcemaps)
 - [html5 rocks sourcemaps post](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/)
+
+## Configuration
+
+In addition to the configuration via `JavaScript` (see examples below), some aspects of es6ify can be configured inside
+the `package.json` file of the package that uses it as a transform.
+
+```json
+{
+  "browserify": {
+    "transform": [ "es6ify" ]
+  },
+  "es6ify": {
+    "filePattern": ".js.es6$",
+    "includeRuntime": true
+  }
+}
+```
+
+In the above example we tell es6ify to only transpile files with the `.js.es6` extension and to include the traceur
+runtime which is needed for certain ES6 features.
 
 ## API
 

--- a/compile.js
+++ b/compile.js
@@ -5,29 +5,31 @@ var Compiler = require('traceur').NodeCompiler
   ;
 
 var traceurOptions = {
-  modules      : 'commonjs',
-  sourceMaps   : true
+    modules      : 'commonjs'
+  , sourceMaps   : true
 };
 
 exports = module.exports = function compileFile(file, contents, traceurOverrides) {
   var options = xtend(traceurOptions, traceurOverrides);
+
   if (typeof options.sourceMap !== 'undefined') {
     console.warn('es6ify: DEPRECATED options.sourceMap has changed to options.sourceMaps (plural)');
     options.sourceMaps = options.sourceMap;
     delete options.sourceMap;
   }
-  try{
-    var compiler = new Compiler(options);
 
-    var result = compiler.compile(contents, file);
-    var sourceMap = compiler.getSourceMap();
-  }catch(errors){
-      return { source: null, sourcemap: null, error: errors[0] };
+  var result, compiler, sourceMap;
+  try {
+    compiler  = new Compiler(options);
+    result    = compiler.compile(contents, file);
+    sourceMap = compiler.getSourceMap();
+  } catch(errors) {
+    return { source: null, sourcemap: null, error: errors[0] };
   }
 
   return {
-      source: result,
-      error: null,
-      sourcemap: sourceMap ? JSON.parse(sourceMap) : null
+    source    : result,
+    error     : null,
+    sourcemap : sourceMap ? JSON.parse(sourceMap) : null
   };
 };

--- a/index.js
+++ b/index.js
@@ -1,14 +1,15 @@
 'use strict';
 
-var SM          = require('source-map')
-  , SMConsumer  = SM.SourceMapConsumer
-  , SMGenerator = SM.SourceMapGenerator
-  , through     = require('through2')
-  , compile     = require('./compile')
-  , crypto      = require('crypto')
-  , path        = require('path')
-  , runtime     = require.resolve(require('traceur').RUNTIME_PATH)
-  , cache       = {};
+var SM            = require('source-map')
+  , SMConsumer    = SM.SourceMapConsumer
+  , SMGenerator   = SM.SourceMapGenerator
+  , through       = require('through2')
+  , compile       = require('./compile')
+  , crypto        = require('crypto')
+  , path          = require('path')
+  , runtime       = require.resolve(require('traceur').RUNTIME_PATH)
+  , resolveConfig = require('./resolve-config')
+  , cache         = {}
 
 function getHash(data) {
   return crypto
@@ -64,17 +65,17 @@ function compileFile(file, src) {
 }
 
 function es6ify(filePattern) {
-  filePattern =  filePattern || /\.js$/;
+  var resolvedFilePattern = filePattern;
 
   return function es6ifyTransform(file) {
 
     // Don't es6ify the traceur runtime
     if (file === runtime) return through();
-
-    if (!filePattern.test(file)) return through();
+    if (resolvedFilePattern && !resolvedFilePattern.test(file)) return through();
 
     var bufs = [];
-    return through(write, end);
+    var stream = through(write, end);
+    return stream;
 
     function write (buf, _, cb) {
       bufs.push(buf);
@@ -82,20 +83,40 @@ function es6ify(filePattern) {
     }
 
     function end (cb) {
-      var data = Buffer.concat(bufs).toString()
-        , hash = getHash(data)
-        , cached = cache[file];
+      var self = stream;
+      resolveConfig(file, onpkgConfig);
 
-      if (!cached || cached.hash !== hash) {
-        try {
-          cache[file] = { compiled: compileFile(file, data), hash: hash };
-        } catch (ex) {
-          return cb(ex);
+      function onpkgConfig(err, conf) {
+        if (err) return self.emit('error', err);
+
+        var includeRuntime = conf.includeRuntime;
+        if (conf.filePattern) resolvedFilePattern = new RegExp(conf.filePattern);
+        else resolvedFilePattern = /\.js$/;
+
+        var data = Buffer.concat(bufs).toString()
+          , hash = getHash(data)
+          , cached = cache[file];
+
+        // This should only be true for the very first file since for the ones
+        // following this one we are doing this check before aggregating the stream data
+        if (!resolvedFilePattern.test(file)) {
+          self.push(data);
+          return cb();
         }
-      }
 
-      this.push(cache[file].compiled);
-      cb();
+        if (!cached || cached.hash !== hash) {
+          // Include traceur runtime automatically if so desired by the user
+          if (conf.includeRuntime) data = 'require(\'' + runtime + '\');\n' + data;
+          try {
+            cache[file] = { compiled: compileFile(file, data), hash: hash };
+          } catch (ex) {
+            return cb(ex);
+          }
+        }
+
+        self.push(cache[file].compiled);
+        cb();
+      }
     }
   };
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/thlorenz/es6ify",
   "dependencies": {
     "source-map": "~0.1.29",
-    "through": "~2.2.7",
+    "through2": "~0.6.3",
     "traceur": "0.0.72",
     "xtend": "~2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "homepage": "https://github.com/thlorenz/es6ify",
   "dependencies": {
+    "mothership": "~0.3.0",
     "source-map": "~0.1.29",
     "through2": "~0.6.3",
     "traceur": "0.0.72",

--- a/resolve-config.js
+++ b/resolve-config.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var mothership = require('mothership')
+  , path = require('path')
+  , si = typeof setImmediate === 'function' ? setImmediate : function setImmediate(fn) { setTimeout(fn, 0) }
+  , pkgConfig
+
+function hasEs6ifyConfig(pkg) {
+  return !!pkg.es6ify;
+}
+
+var go = module.exports = 
+
+/**
+ * Attempts to resolve the `es6ify` config from a `package.json` of the package
+ * that owns the given file or one of its parent packages.
+ *
+ * @name resolveConfig
+ * @function
+ * @private
+ * @param {string} file full path to the file that is being transformed
+ * @param {function} cb called back with an error, or the resolved config - if none is found just `{}`
+ */
+function resolveConfig (file, cb) {
+  if (pkgConfig) return si(cb.bind(null, null, pkgConfig));
+
+  var root = path.dirname(file);
+  mothership(root, hasEs6ifyConfig, function onpkg(err, res) {
+    if (err) return cb(err);
+    
+    pkgConfig = (res && res.pack && res.pack.es6ify) || {}
+    cb(null, pkgConfig);
+  });
+}

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -8,7 +8,8 @@ var es6ify     =  require('..');
 var compile    =  require('../compile');
 var format     =  require('util').format;
 
-[ [ 'run-destructuring'     , [ 'hello, world' ], true ]
+[ 
+  [ 'run-destructuring'     , [ 'hello, world' ], true ]
 //, [ 'run-block-scope'       , [ 'tmp is undefined:  true' ] , false ]
 , [ 'run-default-parameters', [ 'name: Bruno, codes: JavaScript, lives in: USA' ] ]
 , [ 'run-rest-parameters'   , ['list fruits has the following items', 'apple', 'banana' ] ]
@@ -16,7 +17,7 @@ var format     =  require('util').format;
 , [ 'run-spread-operator'   , [ '3 + 4 = 7' ], true ]
 , [ 'run-combined'
   , [ 'hello, world'
-//    , 'tmp is undefined:  true'
+//  , 'tmp is undefined:  true'
     , 'An instance of Foo says hi from its .toString()!'
     , 'name: Bruno, codes: JavaScript, lives in: USA'
     , 'list fruits has the following items', 'apple', 'banana'
@@ -43,10 +44,10 @@ var format     =  require('util').format;
       .require(__dirname + '/bundle/' + filename + '.js', { entry: true })
       .bundle(function (err, src) {
         if (err) t.fail(err);
-        src = 'window=this;'+src;
+        src = 'window=this;' + src;
         vm.runInNewContext(src, {
-            window: {},
-            console: { log: log }
+          window: {},
+          console: { log: log }
         });
         t.end()
       });

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -9,7 +9,7 @@ var compile    =  require('../compile');
 var format     =  require('util').format;
 
 [ 
-  [ 'run-destructuring'     , [ 'hello, world' ], true ]
+  [ 'run-destructuring'     , [ 'hello, world' ], false ]
 //, [ 'run-block-scope'       , [ 'tmp is undefined:  true' ] , false ]
 , [ 'run-default-parameters', [ 'name: Bruno, codes: JavaScript, lives in: USA' ] ]
 , [ 'run-rest-parameters'   , ['list fruits has the following items', 'apple', 'banana' ] ]

--- a/test/config-file-pattern.js
+++ b/test/config-file-pattern.js
@@ -1,0 +1,42 @@
+'use strict';
+/*jshint asi: true */
+
+var test       = require('tap').test;
+var browserify = require('browserify');
+var es6ify     = require('..');
+var path       = require('path');
+var vm         = require('vm');
+
+test('\nwhen file pattern specified in package.json includes is /.js.es6$/ and I require punk.js.es6', function (t) {
+  t.plan(1);
+  browserify()
+    .transform(es6ify)
+    .require(__dirname + '/config-file-pattern/punk.js.es6', { entry: true })
+    .bundle(function (err, src) {
+      if (err) { t.fail(err); return t.end(); }
+
+      try {
+        vm.runInNewContext(src, { window: {}, })
+      } catch (err) {
+        t.equal(err.name, 'ReferenceError', 'running it fails since "use strict" was added')
+      }
+      t.end();
+    });
+});
+
+test('\nwhen file pattern specified in package.json includes is /.js.es6$/ and I require punk.js', function (t) {
+  t.plan(1);
+  browserify()
+    .transform(es6ify)
+    .require(__dirname + '/config-file-pattern/punk.js', { entry: true })
+    .bundle(function (err, src) {
+      if (err) { t.fail(err); return t.end(); }
+
+      vm.runInNewContext(src, { window: {}, console: { log: log } })
+      t.end();
+    });
+
+    function log(a) {
+      t.equal(a, "I'm the trouble starter, punking instigator", 'runs the code violating strict correclty')
+    }
+});

--- a/test/config-file-pattern/package.json
+++ b/test/config-file-pattern/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "config-file-pattern",
+  "version": "0.0.0",
+  "description": "Demonstrating how to configure the file pattern via es6ify config in the package.json.",
+  "es6ify": {
+    "filePattern": ".js.es6$"
+  }
+}

--- a/test/config-file-pattern/punk.js
+++ b/test/config-file-pattern/punk.js
@@ -1,0 +1,5 @@
+module.exports = (function poop() {
+  // this blows up in strict mode
+  a = "I'm the trouble starter, punking instigator"
+  console.log(a);
+})()

--- a/test/config-file-pattern/punk.js.es6
+++ b/test/config-file-pattern/punk.js.es6
@@ -1,0 +1,5 @@
+module.exports = (function poop() {
+  // this blows up in strict mode
+  a = "I'm the trouble starter, punking instigator"
+  console.log(a);
+})()

--- a/test/config-include-runtime-not.js
+++ b/test/config-include-runtime-not.js
@@ -1,0 +1,28 @@
+'use strict';
+/*jshint asi: true */
+
+var test       = require('tap').test;
+var browserify = require('browserify');
+var es6ify     = require('..');
+var path       = require('path');
+var vm         = require('vm');
+
+test('\nwhen not including runtime via package.json and transpiling a script that needs it inside that package', function (t) {
+  t.plan(1);
+  browserify()
+    .transform(es6ify)
+    .require(__dirname + '/config-include-runtime-not/main.js', { entry: true })
+    .bundle(function (err, src) {
+      if (err) { t.fail(err); return t.end(); }
+
+      src = 'window=this;' + src;
+
+      try {
+        vm.runInNewContext(src, { window: {}, })
+      } catch (err) {
+        t.equal(err.name, 'ReferenceError', 'running should fail indicating that traceur runtime is missing');
+      }
+
+      t.end();
+    });
+});

--- a/test/config-include-runtime-not/main.js
+++ b/test/config-include-runtime-not/main.js
@@ -1,0 +1,9 @@
+class Foo {
+  toString() {
+      return 'An instance of Foo says hi from its .toString()!';
+  }
+}
+
+module.exports = (function () {
+ console.log(new Foo().toString());
+})();

--- a/test/config-include-runtime-not/package.json
+++ b/test/config-include-runtime-not/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "config-include-runtime-not",
+  "version": "0.0.0",
+  "description": "Demonstrating how to configure the traceur runtime exclusion via es6ify config in the package.json.",
+  "es6ify": {
+    "includeRuntime": false
+  }
+}

--- a/test/config-include-runtime.js
+++ b/test/config-include-runtime.js
@@ -1,0 +1,26 @@
+'use strict';
+/*jshint asi: true */
+
+var test       = require('tap').test;
+var browserify = require('browserify');
+var es6ify     = require('..');
+var path       = require('path');
+var vm         = require('vm');
+
+test('\nwhen including runtime via package.json and transpiling a script that needs it inside that package', function (t) {
+  t.plan(1)
+  browserify()
+    .transform(es6ify)
+    .require(__dirname + '/config-include-runtime/main.js', { entry: true })
+    .bundle(function (err, src) {
+      if (err) { t.fail(err); return t.end(); }
+      src = 'window=this;' + src;
+
+      vm.runInNewContext(src, { window: {}, console: { log: log } })
+      t.end();
+    });
+
+  function log(s) {
+    t.equal(s, 'An instance of Foo says hi from its .toString()!', 'transpiles and runs es6 code correctly')
+  }
+});

--- a/test/config-include-runtime/main.js
+++ b/test/config-include-runtime/main.js
@@ -1,0 +1,9 @@
+class Foo {
+  toString() {
+      return 'An instance of Foo says hi from its .toString()!';
+  }
+}
+
+module.exports = (function () {
+ console.log(new Foo().toString());
+})();

--- a/test/config-include-runtime/package.json
+++ b/test/config-include-runtime/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "config-include-runtime",
+  "version": "0.0.0",
+  "description": "Demonstrating how to configure the traceur runtime inclusion via es6ify config in the package.json.",
+  "es6ify": {
+    "includeRuntime": true
+  }
+}

--- a/test/transform.js
+++ b/test/transform.js
@@ -4,7 +4,7 @@
 var test       =  require('tap').test
   , fs         =  require('fs')
   , path       =  require('path')
-  , through    =  require('through')
+  , through    =  require('through2')
   , convert    =  require('convert-source-map')
   , compile    =  require('../compile')
   , proxyquire =  require('proxyquire')
@@ -37,8 +37,8 @@ test('transform adds sourcemap comment and uses cache on second time', function 
       .on('error', console.error)
       .pipe(through(write, end));
 
-    function write (buf) { data += buf; }
-    function end () {
+    function write (buf, _, cb) { data += buf; cb(); }
+    function end (cb) {
       var sourceMap = convert.fromSource(data).toObject();
       t.deepEqual(
           sourceMap
@@ -52,5 +52,6 @@ test('transform adds sourcemap comment and uses cache on second time', function 
       );
       t.ok(sourceMap.mappings.length);
       t.equal(compiles, 1, 'compiles only the first time');
+      cb();
     }
 });


### PR DESCRIPTION
This PR adds ability to configure some es6ify options (at this point two) via the `package.json`:

``` json
{
  "browserify": {
    "transform": [ "es6ify" ]
  },
  "es6ify": {
    "filePattern": ".js.es6$",
    "includeRuntime": true
  }
}
```

Just wanted to get your lgtm @domenic before I merge this in.

We should also discuss here what additional options we should make configurable via the `package.json` and how to merge it with transform options passed in directly (if we ever go that route [as indicated in this branch](https://github.com/thlorenz/es6ify/tree/v2-api)).

We also should think about deprecating configuration options done via JavaScript as they will become redundant and are not a good way of doing this anyhow.
