### PR TITLE
Add support for subarg to allow passing file extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,10 @@ function compileFile(file, src) {
 function es6ify(filePattern) {
   filePattern =  filePattern || /\.js$/;
 
-  return function (file) {
+  return function (file, opts) {
+    if (opts && opts.extension) {
+      filePattern = new RegExp(opts.extension);
+    }
 
     // Don't es6ify the traceur runtime
     if (file === runtime) return through();

--- a/test/fixtures/log.js
+++ b/test/fixtures/log.js
@@ -1,0 +1,5 @@
+"use strict";
+var log = (function(msg) {
+  return console.log(msg);
+});
+module.exports = log;

--- a/test/fixtures/log.js.es6
+++ b/test/fixtures/log.js.es6
@@ -1,0 +1,3 @@
+var log = msg => console.log(msg);
+
+module.exports = log;

--- a/test/subarg.js
+++ b/test/subarg.js
@@ -1,0 +1,25 @@
+var es6ify     =  require('..')
+  , test       =  require('tap').test
+  , fs         =  require('fs')
+  , path       =  require('path')
+  , through    =  require('through');
+
+test('accepts optional argument for file pattern', function(t) {
+
+    t.plan(1);
+    var data = '';
+    var file = path.join(__dirname, 'fixtures/log.js.es6');
+
+    fs.createReadStream(file)
+      .pipe(es6ify(file, {extension: '.js.es6'}))
+      .on('error', console.error)
+      .pipe(through(write, end));
+
+    function write (buf) { data += buf; }
+
+    function end () {
+      var expectedOutput = fs.readFileSync(path.join(__dirname, 'fixtures/log.js'));
+
+      t.equal(data.indexOf(expectedOutput), 0);
+    }
+});


### PR DESCRIPTION
Browserify supports passing arguments to transforms via subarg. This
commit adds support for that so we can use es6ify on the command line
like so:

  `browserify -t [es6ify --extension=.js.es6] input.js`
