### PR TITLE
Fix sourcemaps with traceur 0.0.72

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -6,19 +6,20 @@ var Compiler = require('traceur').NodeCompiler
 
 var traceurOptions = {
   modules      : 'commonjs',
-  sourceMaps   : true
+  sourceMaps   : 'inline'
 };
 
 function buildTraceurOptions(overrides) {
   var options = xtend(traceurOptions, overrides);
 
   if (typeof options.sourceMap !== 'undefined') {
-    console.warn('es6ify: DEPRECATED options.sourceMap has changed to options.sourceMaps (plural)');
+    console.warn('es6ify: DEPRECATED traceurOverrides.sourceMap has changed to traceurOverrides.sourceMaps (plural)');
     options.sourceMaps = options.sourceMap;
     delete options.sourceMap;
   }
 
   if (options.sourceMaps === true) {
+    console.warn('es6ify: DEPRECATED "traceurOverrides.sourceMaps = true" is not a valid option, traceur sourceMaps options are [false|inline|file]');
     options.sourceMaps = 'inline';
   }
 

--- a/compile.js
+++ b/compile.js
@@ -9,25 +9,34 @@ var traceurOptions = {
   sourceMaps   : true
 };
 
-exports = module.exports = function compileFile(file, contents, traceurOverrides) {
-  var options = xtend(traceurOptions, traceurOverrides);
+function buildTraceurOptions(overrides) {
+  var options = xtend(traceurOptions, overrides);
+
   if (typeof options.sourceMap !== 'undefined') {
     console.warn('es6ify: DEPRECATED options.sourceMap has changed to options.sourceMaps (plural)');
     options.sourceMaps = options.sourceMap;
     delete options.sourceMap;
   }
+
+  if (options.sourceMaps === true) {
+    options.sourceMaps = 'inline';
+  }
+
+  return options;
+}
+
+exports = module.exports = function compileFile(file, contents, traceurOverrides) {
+  var options = buildTraceurOptions(traceurOverrides);
   try{
     var compiler = new Compiler(options);
 
-    var result = compiler.compile(contents, file);
-    var sourceMap = compiler.getSourceMap();
+    var result = compiler.compile(contents, file, file + '.es6');
   }catch(errors){
-      return { source: null, sourcemap: null, error: errors[0] };
+      return { source: null, error: errors[0] };
   }
 
   return {
       source: result,
-      error: null,
-      sourcemap: sourceMap ? JSON.parse(sourceMap) : null
+      error: null
   };
 };

--- a/compile.js
+++ b/compile.js
@@ -30,7 +30,7 @@ exports = module.exports = function compileFile(file, contents, traceurOverrides
   try{
     var compiler = new Compiler(options);
 
-    var result = compiler.compile(contents, file, file + '.es6');
+    var result = compiler.compile(contents, file, file);
   }catch(errors){
       return { source: null, error: errors[0] };
   }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
 'use strict';
 
-var SM          = require('source-map')
-  , SMConsumer  = SM.SourceMapConsumer
-  , SMGenerator = SM.SourceMapGenerator
-  , through     =  require('through')
+var through     =  require('through')
   , compile     =  require('./compile')
   , crypto      =  require('crypto')
   , path        =  require('path')
@@ -31,36 +28,7 @@ function compileFile(file, src) {
   compiled = compile(file, src, exports.traceurOverrides);
   if (compiled.error) throw new Error(compiled.error);
 
-  var comment
-    , consumer = new SMConsumer(compiled.sourcemap)
-    , generator = new SMGenerator({file: file + '.es6'});
-
-  generator.setSourceContent(file, src);
-
-  consumer.eachMapping(function (mapping) {
-    mapping.source = path.normalize(mapping.source);
-    // Ignore mappings that are not from our source file
-    if(mapping.source && file === mapping.source) {
-      generator.addMapping(
-        {
-          original: {
-            column: mapping.originalColumn
-          , line: mapping.originalLine
-          }
-        , generated: {
-            column: mapping.generatedColumn
-          , line: mapping.generatedLine
-          }
-        , source: file
-        , name: mapping.name
-        }
-      );
-    }
-  });
-
-  comment = new Buffer(generator.toString()).toString('base64');
-
-  return compiled.source + '\n//@ sourceMappingURL=data:application/json;base64,' + comment;
+  return compiled.source;
 }
 
 function es6ify(filePattern) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "homepage": "https://github.com/thlorenz/es6ify",
   "dependencies": {
-    "source-map": "~0.1.29",
     "through": "~2.2.7",
     "traceur": "0.0.72",
     "xtend": "~2.2.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "tap": "~0.4.0",
     "proxyquire": "~0.4.0",
-    "convert-source-map": "~0.2.6",
+    "convert-source-map": "~0.4.1",
     "browserify": "~5.12.1"
   },
   "keywords": [

--- a/test/transform.js
+++ b/test/transform.js
@@ -43,11 +43,15 @@ test('transform adds sourcemap comment and uses cache on second time', function 
       t.deepEqual(
           sourceMap
         , { version: 3,
-            file: file + '.es6',
-            sources: [ file ],
+            file: file,
+            sources: [ file, '@traceur/generated/TemplateParser/1' ],
             names: [],
             mappings: sourceMap.mappings,
-            sourcesContent: [ 'module.exports = function () {\n  for (let element of [1, 2, 3]) {\n    console.log(\'element:\', element);\n  }\n};\n' ] }
+            sourceRoot: path.join(path.dirname(file), path.sep),
+            sourcesContent: [
+              'module.exports = function () {\n  for (let element of [1, 2, 3]) {\n    console.log(\'element:\', element);\n  }\n};\n',
+              '\n        for (var $__placeholder__0 =\n                 $__placeholder__1[Symbol.iterator](),\n                 $__placeholder__2;\n             !($__placeholder__3 = $__placeholder__4.next()).done; ) {\n          $__placeholder__5;\n          $__placeholder__6;\n        }'
+            ] }
         , 'adds sourcemap comment including original source'
       );
       t.ok(sourceMap.mappings.length);


### PR DESCRIPTION
Fixes #68 

@thlorenz I am not sure what's the benefit of rebuilding the sourcemap to "Ignore mappings that are not from our source file". Could you please explain? Thanks.
