### PR TITLE
Bump Traceur to 0.0.82

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -32,9 +32,19 @@ exports = module.exports = function compileFile(file, contents, opts) {
   try{
     var compiler = new Compiler(buildTraceurOptions(opts.traceurOverrides));
 
-    var outFile = opts.sourceRoot ? path.relative(opts.sourceRoot, file) : file;
+    var outFile =
+      opts.basedir !== undefined ?
+      path.relative(opts.basedir, file) :
+      file;
 
-    var result = compiler.compile(contents, file, outFile, opts.sourceRoot);
+    // opts.basedir is passed here as the `sourceRoot` param, which traceur
+    // totally misappropriates. See
+    // https://github.com/google/traceur-compiler/issues/1676
+    // It's ok for here for now because it gets the
+    // correct path populated in `sources` and browserify overwrites sourceRoot.
+    // This should be revisited to see if a relative path should be passed in
+    // `file` and what `sourceRoot` value, if any, should be passed.
+    var result = compiler.compile(contents, file, outFile, opts.basedir);
   }catch(errors){
       return { source: null, error: errors[0] };
   }

--- a/compile.js
+++ b/compile.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var path = require('path');
+
 var Compiler = require('traceur').NodeCompiler
   , xtend = require('xtend')
   ;
@@ -30,7 +32,9 @@ exports = module.exports = function compileFile(file, contents, opts) {
   try{
     var compiler = new Compiler(buildTraceurOptions(opts.traceurOverrides));
 
-    var result = compiler.compile(contents, file, file, opts.sourceRoot);
+    var outFile = opts.sourceRoot ? path.relative(opts.sourceRoot, file) : file;
+
+    var result = compiler.compile(contents, file, outFile, opts.sourceRoot);
   }catch(errors){
       return { source: null, error: errors[0] };
   }

--- a/compile.js
+++ b/compile.js
@@ -26,12 +26,11 @@ function buildTraceurOptions(overrides) {
   return options;
 }
 
-exports = module.exports = function compileFile(file, contents, traceurOverrides) {
-  var options = buildTraceurOptions(traceurOverrides);
+exports = module.exports = function compileFile(file, contents, opts) {
   try{
-    var compiler = new Compiler(options);
+    var compiler = new Compiler(buildTraceurOptions(opts.traceurOverrides));
 
-    var result = compiler.compile(contents, file, file);
+    var result = compiler.compile(contents, file, file, opts.sourceRoot);
   }catch(errors){
       return { source: null, error: errors[0] };
   }

--- a/index.js
+++ b/index.js
@@ -33,13 +33,14 @@ function compileFile(file, src, opts) {
 }
 
 function es6ify(opts) {
-  opts || (opts = {});
+  if (opts === undefined) opts = {};
 
   // This function's argument used to be filePattern (regex), so duck type opts
   // to see if it's meant as filePattern.
   if (typeof opts.ignoreCase !== 'undefined') opts = {filePattern: opts};
 
-  var filePattern = opts.filePattern = opts.filePattern || /\.js$/;
+  if (opts.filePattern === undefined) opts.filePattern = /\.js$/;
+  var filePattern = opts.filePattern;
 
   return function (file) {
 

--- a/index.js
+++ b/index.js
@@ -88,7 +88,9 @@ exports = module.exports = es6ify();
  *
  * @name es6ify::configure
  * @function
- * @param {string=} filePattern (default: `/\.js$/) pattern of files that will be es6ified
+ * @param {{filePattern: (undefined|!RegExp), sourceRoot: (undefined|string)}=} opts
+ * filePattern (default: `/\.js$/`) pattern of files that will be es6ified
+ * sourceRoot Path that `sources` paths are relative to.
  * @return {function} function that returns a `TransformStream` when called with a `file`
  */
 exports.configure = es6ify;

--- a/index.js
+++ b/index.js
@@ -35,10 +35,6 @@ function compileFile(file, src, opts) {
 function es6ify(opts) {
   if (opts === undefined) opts = {};
 
-  // This function's argument used to be filePattern (regex), so duck type opts
-  // to see if it's meant as filePattern.
-  if (typeof opts.ignoreCase !== 'undefined') opts = {filePattern: opts};
-
   if (opts.filePattern === undefined) opts.filePattern = /\.js$/;
   var filePattern = opts.filePattern;
 

--- a/index.js
+++ b/index.js
@@ -23,16 +23,23 @@ function getHash(data) {
  * @param {string} src source of the file being compiled to ES5
  * @return {string} compiled source
  */
-function compileFile(file, src) {
+function compileFile(file, src, opts) {
   var compiled;
-  compiled = compile(file, src, exports.traceurOverrides);
+  opts.traceurOverrides = exports.traceurOverrides;
+  compiled = compile(file, src, opts);
   if (compiled.error) throw new Error(compiled.error);
 
   return compiled.source;
 }
 
-function es6ify(filePattern) {
-  filePattern =  filePattern || /\.js$/;
+function es6ify(opts) {
+  opts || (opts = {});
+
+  // This function's argument used to be filePattern (regex), so duck type opts
+  // to see if it's meant as filePattern.
+  if (typeof opts.ignoreCase !== 'undefined') opts = {filePattern: opts};
+
+  var filePattern = opts.filePattern = opts.filePattern || /\.js$/;
 
   return function (file) {
 
@@ -51,7 +58,7 @@ function es6ify(filePattern) {
 
       if (!cached || cached.hash !== hash) {
         try {
-          cache[file] = { compiled: compileFile(file, data), hash: hash };
+          cache[file] = { compiled: compileFile(file, data, opts), hash: hash };
         } catch (ex) {
           this.emit('error', ex);
           return this.queue(null);

--- a/index.js
+++ b/index.js
@@ -88,9 +88,9 @@ exports = module.exports = es6ify();
  *
  * @name es6ify::configure
  * @function
- * @param {{filePattern: (undefined|!RegExp), sourceRoot: (undefined|string)}=} opts
+ * @param {{filePattern: (undefined|!RegExp), basedir: (undefined|string)}=} opts
  * filePattern (default: `/\.js$/`) pattern of files that will be es6ified
- * sourceRoot Path that `sources` paths are relative to.
+ * basedir Base path to compute relative paths for `sources`
  * @return {function} function that returns a `TransformStream` when called with a `file`
  */
 exports.configure = es6ify;

--- a/index.js
+++ b/index.js
@@ -34,8 +34,10 @@ function compileFile(file, src, opts) {
 
 function es6ify(opts) {
   if (opts === undefined) opts = {};
-
   if (opts.filePattern === undefined) opts.filePattern = /\.js$/;
+  else if (!(opts.filePattern instanceof RegExp)) {
+    throw new Error("`filePattern` must be a RegExp if defined.");
+  }
   var filePattern = opts.filePattern;
 
   return function (file) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://thlorenz.github.io/es6ify/",
   "dependencies": {
     "through": "~2.2.7",
-    "traceur": "0.0.79",
+    "traceur": "0.0.82",
     "xtend": "~2.2.0"
   },
   "devDependencies": {

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -46,7 +46,11 @@ var format     =  require('util').format;
         src = 'window=this;'+src;
         vm.runInNewContext(src, {
             window: {},
-            console: { log: log }
+            console: { log: log },
+            // See:
+            // https://github.com/thlorenz/es6ify/issues/79
+            // https://github.com/joyent/node/issues/9121
+            Float32Array: Float32Array,
         });
         t.end()
       });

--- a/test/transform.js
+++ b/test/transform.js
@@ -88,7 +88,7 @@ function addsSourceMap (t, opts) {
     [undefined, end].forEach(function (end) {
       fs.createReadStream(paths.in.file)
         .pipe(es6ify(paths.in.file))
-        .on('error', console.error)
+        .on('error', function (e) { throw e; })
         .pipe(through(write, end));
     });
   }

--- a/test/transform.js
+++ b/test/transform.js
@@ -8,6 +8,24 @@ var test       =  require('tap').test
   , convert    =  require('convert-source-map')
   , compile    =  require('../compile')
   , proxyquire =  require('proxyquire')
+  , cache = {}
+
+/**
+ * Check the cache for path, or read from fs and cache, and return contents.
+ * @param {string} path
+ * @returns {string}
+ */
+function readFileCache (path) {
+  var file =
+    cache[path] !== undefined ?
+    cache[path] :
+    fs.readFileSync(path, { encoding: 'utf8' });
+
+  cache[path] = file;
+
+  return file;
+}
+// readFileCache
 
 /**
  * @function
@@ -40,7 +58,7 @@ function addsSourceMap (t, opts) {
   var es6ify = proxyquire('..', { './compile' : trackingCompile } )
   es6ify = es6ify.configure(es6ifyOpts);
 
-  var contents = fs.readFileSync(paths.in.file, { encoding: 'utf8' });
+  var contents = readFileCache(paths.in.file);
 
   // Run without, then with, `end()`
   [undefined, end].forEach(function (end) {
@@ -85,7 +103,7 @@ function addsSourceMap (t, opts) {
           sourceRoot: paths.out.sourceRoot,
           sourcesContent: [
             contents,
-            fs.readFileSync(
+            readFileCache(
               path.join(
                 __dirname, 'transform', 'traceur-generated-template-parser.js'
               ),

--- a/test/transform.js
+++ b/test/transform.js
@@ -85,16 +85,13 @@ function addsSourceMap (t, opts) {
           sourceRoot: paths.out.sourceRoot,
           sourcesContent: [
             contents,
-
-            '\n        for (var $__placeholder__0 =\n' +
-            '                 $__placeholder__1[\n' +
-            '                     $traceurRuntime.toProperty(Symbol.iterator)](),\n' +
-            '                 $__placeholder__2;\n' +
-            '             !($__placeholder__3 = $__placeholder__4.next()).done; ) {\n' +
-            '          $__placeholder__5;\n' +
-            '          $__placeholder__6;\n' +
-            '        }',
-
+            fs.readFileSync(
+              path.join(
+                __dirname, 'transform', 'traceur-generated-template-parser.js'
+              ),
+              { encoding: 'utf8' }
+            )
+              .replace(/\s+$/, ''),
             'void 0'
           ] }
       , 'adds sourcemap comment including original source'

--- a/test/transform.js
+++ b/test/transform.js
@@ -62,7 +62,9 @@ function addsSourceMap (t, opts) {
   paths.in.file = path.join(paths.in.sourceRoot, paths.in.sources);
 
   var es6ifyOpts = {};
-  if (opts.useSourceRoot) es6ifyOpts.sourceRoot = paths.in.sourceRoot;
+  // Traceur misappropriates sourceRoot to apply to local input paths, so the
+  // public option for es6ify is named basedir.
+  if (opts.useSourceRoot) es6ifyOpts.basedir = paths.in.sourceRoot;
   var es6ify = proxyquire('..', { './compile' : trackingCompile } )
   es6ify = es6ify.configure(es6ifyOpts);
 

--- a/test/transform.js
+++ b/test/transform.js
@@ -9,96 +9,99 @@ var test       =  require('tap').test
   , compile    =  require('../compile')
   , proxyquire =  require('proxyquire')
 
+/**
+ * @function
+ * @param {{useSourceRoot: boolean}} opts
+ * useSourceRoot Do or don't specify sourceRoot to traceur.
+ */
+function addsSourceMap (t, opts) {
+  t.plan(3);
+  var data = '';
+  var compiles = 0;
+
+  function trackingCompile() {
+    compiles++;
+    var args = [].slice.call(arguments);
+    return compile.apply(this, args);
+  }
+
+  // Input / output paths
+  var paths = { out: {} };
+
+  paths.in = {
+    sourceRoot: path.join(__dirname, '..', 'example', 'src'),
+    // Path that should wind up in `sources` in the map when sourceRoot is used.
+    sources: path.join('features', 'iterators.js'),
+  };
+  paths.in.file = path.join(paths.in.sourceRoot, paths.in.sources);
+
+  var es6ifyOpts = { sourceRoot: paths.in.sourceRoot };
+  var es6ify = proxyquire('..', { './compile' : trackingCompile } )
+  es6ify = es6ify.configure(es6ifyOpts);
+
+  var contents = fs.readFileSync(paths.in.file, { encoding: 'utf8' });
+
+  // Run without, then with, `end()`
+  [undefined, end].forEach(function (end) {
+    fs.createReadStream(paths.in.file)
+      .pipe(es6ify(paths.in.file))
+      .on('error', console.error)
+      .pipe(through(write, end));
+  });
+
+  function write (buf) { data += buf; }
+  function end () {
+    var sourceMap = convert.fromSource(data).toObject();
+
+    // Traceur converts all \s to /s so we need to do so also before comparing
+    paths.out.file = (es6ifyOpts.sourceRoot ? paths.in.sources : paths.in.file)
+      .replace(/\\/g, '/');
+
+    paths.out.sources = paths.in.sources.replace(/\\/g, '/');
+
+    paths.out.sourceRoot = (
+      es6ifyOpts.sourceRoot ?
+      paths.in.sourceRoot :
+      path.dirname(paths.in.file) + '/'
+    )
+      .replace(/\\/g, '/');
+
+    t.deepEqual(
+        sourceMap
+      , { version: 3,
+          file: paths.out.file,
+          sources: [
+            paths.out.sources,
+            '@traceur/generated/TemplateParser/2',
+            '@traceur/generated/TemplateParser/3',
+          ],
+          names: [],
+          mappings: sourceMap.mappings,
+          sourceRoot: paths.out.sourceRoot,
+          sourcesContent: [
+            contents,
+
+            '\n        for (var $__placeholder__0 =\n' +
+            '                 $__placeholder__1[\n' +
+            '                     $traceurRuntime.toProperty(Symbol.iterator)](),\n' +
+            '                 $__placeholder__2;\n' +
+            '             !($__placeholder__3 = $__placeholder__4.next()).done; ) {\n' +
+            '          $__placeholder__5;\n' +
+            '          $__placeholder__6;\n' +
+            '        }',
+
+            'void 0'
+          ] }
+      , 'adds sourcemap comment including original source'
+    );
+    t.ok(sourceMap.mappings.length);
+    t.equal(compiles, 1, 'compiles only the first time');
+  }
+}
+// addsSourceMap
+
 test('transform adds sourcemap comment and uses cache on second time', function (t) {
-    t.plan(3);
-    var data = '';
-    var compiles = 0;
 
-    function trackingCompile() {
-      compiles++;
-      var args = [].slice.call(arguments);
-      return compile.apply(this, args);
-    }
-
-    // Input / output paths
-    var paths = { out: {} };
-
-    paths.in = {
-      sourceRoot: path.join(__dirname, '..', 'example', 'src'),
-      // Path that should wind up in `sources` in the map when sourceRoot is
-      // used.
-      sources: path.join('features', 'iterators.js'),
-    };
-    paths.in.file = path.join(paths.in.sourceRoot, paths.in.sources);
-
-    var opts = { sourceRoot: sourceRoot };
-
-    if (opts.sourceRoot === undefined) {
-      paths.in.sources = path.basename(paths.in.file);
-    }
-
-    var es6ify = proxyquire('..', { './compile' : trackingCompile } )
-
-    es6ify = es6ify.configure(opts);
-
-    var contents = fs.readFileSync(paths.in.file, { encoding: 'utf8' });
-
-    // Run without, then with, `end()`
-    [undefined, end].forEach(function (end) {
-      fs.createReadStream(paths.in.file)
-        .pipe(es6ify(paths.in.file))
-        .on('error', console.error)
-        .pipe(through(write, end));
-    });
-
-    function write (buf) { data += buf; }
-    function end () {
-      var sourceMap = convert.fromSource(data).toObject();
-
-      // Traceur converts all \s to /s so we need to do so also before comparing
-      paths.out.file = (opts.sourceRoot ? paths.in.sources : paths.in.file)
-        .replace(/\\/g, '/');
-
-      paths.out.sources = paths.in.sources.replace(/\\/g, '/');
-
-      paths.out.sourceRoot = (
-        opts.sourceRoot ?
-        paths.in.sourceRoot :
-        path.dirname(paths.in.file) + '/'
-      )
-        .replace(/\\/g, '/');
-
-      t.deepEqual(
-          sourceMap
-        , { version: 3,
-            file: paths.out.file,
-            sources: [
-              paths.out.sources,
-              '@traceur/generated/TemplateParser/2',
-              '@traceur/generated/TemplateParser/3',
-            ],
-            names: [],
-            mappings: sourceMap.mappings,
-            sourceRoot: paths.out.sourceRoot,
-            sourcesContent: [
-              contents,
-
-              '\n        for (var $__placeholder__0 =\n' +
-              '                 $__placeholder__1[\n' +
-              '                     $traceurRuntime.toProperty(Symbol.iterator)](),\n' +
-              '                 $__placeholder__2;\n' +
-              '             !($__placeholder__3 = $__placeholder__4.next()).done; ) {\n' +
-              '          $__placeholder__5;\n' +
-              '          $__placeholder__6;\n' +
-              '        }',
-
-              'void 0'
-            ] }
-        , 'adds sourcemap comment including original source'
-      );
-      t.ok(sourceMap.mappings.length);
-      t.equal(compiles, 1, 'compiles only the first time');
-    }
 });
 
 test('transform does not add sourcemaps if traceurOverrides.sourceMaps is false', function (t) {

--- a/test/transform.js
+++ b/test/transform.js
@@ -26,14 +26,14 @@ test('transform adds sourcemap comment and uses cache on second time', function 
     var sourceRoot = path.join(__dirname, '..', 'example', 'src');
     var relPath = path.join('features', 'iterators.js');
 
-    var opts = {sourceRoot: sourceRoot};
+    var opts = { sourceRoot: sourceRoot };
 
     es6ify = es6ify.configure(opts);
 
     var file = path.join(sourceRoot, relPath);
-    if (! opts.sourceRoot) relPath = path.basename(file);
+    if (opts.sourceRoot === undefined) relPath = path.basename(file);
 
-    var contents = fs.readFileSync(file).toString();
+    var contents = fs.readFileSync(file, { encoding: 'utf8' });
 
     // first time
     fs.createReadStream(file)

--- a/test/transform.js
+++ b/test/transform.js
@@ -98,17 +98,16 @@ function addsSourceMap (t, opts) {
   function end () {
     var sourceMap = convert.fromSource(data).toObject();
 
-    paths.out.sources =
-      opts.useSourceRoot ?
-      paths.in.sources :
-      path.basename(paths.in.sources);
-
-    paths.out.file = opts.useSourceRoot ? paths.out.sources : paths.in.file;
-
-    paths.out.sourceRoot =
-      opts.useSourceRoot ?
-      paths.in.sourceRoot :
-      path.dirname(paths.in.file) + '/';
+    if (opts.useSourceRoot) {
+      paths.out.sources = paths.in.sources;
+      paths.out.file = paths.out.sources;
+      paths.out.sourceRoot = paths.in.sourceRoot;
+    }
+    else {
+      paths.out.sources = path.basename(paths.in.sources);
+      paths.out.file = paths.in.file;
+      paths.out.sourceRoot = path.dirname(paths.in.file) + '/';
+    }
 
     // Traceur converts all "\" to "/" so we need to do so also before comparing
     Object.keys(paths.out).forEach(function (key) {

--- a/test/transform.js
+++ b/test/transform.js
@@ -54,23 +54,22 @@ function addsSourceMap (t, opts) {
   function end () {
     var sourceMap = convert.fromSource(data).toObject();
 
-    // Traceur converts all \s to /s so we need to do so also before comparing
-    paths.out.sources = (
+    paths.out.sources =
       opts.useSourceRoot ?
       paths.in.sources :
-      path.basename(paths.in.sources)
-    )
-      .replace(/\\/g, '/');
+      path.basename(paths.in.sources);
 
-    paths.out.file = (opts.useSourceRoot ? paths.out.sources : paths.in.file)
-      .replace(/\\/g, '/');
+    paths.out.file = opts.useSourceRoot ? paths.out.sources : paths.in.file;
 
-    paths.out.sourceRoot = (
+    paths.out.sourceRoot =
       opts.useSourceRoot ?
       paths.in.sourceRoot :
-      path.dirname(paths.in.file) + '/'
-    )
-      .replace(/\\/g, '/');
+      path.dirname(paths.in.file) + '/';
+
+    // Traceur converts all "\" to "/" so we need to do so also before comparing
+    Object.keys(paths.out).forEach(function (key) {
+      paths.out[key] = paths.out[key].replace(/\\/g, '/');
+    });
 
     t.deepEqual(
         sourceMap

--- a/test/transform.js
+++ b/test/transform.js
@@ -120,8 +120,12 @@ function addsSourceMap (t, opts) {
 }
 // addsSourceMap
 
-test('transform adds sourcemap comment and uses cache on second time', function (t) {
+test("transform adds sourcemap comment, doesn't use sourceRoot, and uses cache on second time", function (t) {
+  addsSourceMap(t, { useSourceRoot: false });
+});
 
+test("transform adds sourcemap comment, uses sourceRoot, and uses cache on second time", function (t) {
+  addsSourceMap(t, { useSourceRoot: true });
 });
 
 test('transform does not add sourcemaps if traceurOverrides.sourceMaps is false', function (t) {

--- a/test/transform.js
+++ b/test/transform.js
@@ -41,18 +41,15 @@ test('transform adds sourcemap comment and uses cache on second time', function 
 
     es6ify = es6ify.configure(opts);
 
-    // first time
-    fs.createReadStream(file)
-      .pipe(es6ify(file))
-      .on('error', console.error)
-      .pipe(through(write));
     var contents = fs.readFileSync(paths.in.file, { encoding: 'utf8' });
 
-    // second time
-    fs.createReadStream(file)
-      .pipe(es6ify(file))
-      .on('error', console.error)
-      .pipe(through(write, end));
+    // Run without, then with, `end()`
+    [undefined, end].forEach(function (end) {
+      fs.createReadStream(paths.in.file)
+        .pipe(es6ify(paths.in.file))
+        .on('error', console.error)
+        .pipe(through(write, end));
+    });
 
     function write (buf) { data += buf; }
     function end () {

--- a/test/transform.js
+++ b/test/transform.js
@@ -35,7 +35,8 @@ function addsSourceMap (t, opts) {
   };
   paths.in.file = path.join(paths.in.sourceRoot, paths.in.sources);
 
-  var es6ifyOpts = { sourceRoot: paths.in.sourceRoot };
+  var es6ifyOpts = {};
+  if (opts.useSourceRoot) es6ifyOpts.sourceRoot = paths.in.sourceRoot;
   var es6ify = proxyquire('..', { './compile' : trackingCompile } )
   es6ify = es6ify.configure(es6ifyOpts);
 
@@ -54,13 +55,18 @@ function addsSourceMap (t, opts) {
     var sourceMap = convert.fromSource(data).toObject();
 
     // Traceur converts all \s to /s so we need to do so also before comparing
-    paths.out.file = (es6ifyOpts.sourceRoot ? paths.in.sources : paths.in.file)
+    paths.out.sources = (
+      opts.useSourceRoot ?
+      paths.in.sources :
+      path.basename(paths.in.sources)
+    )
       .replace(/\\/g, '/');
 
-    paths.out.sources = paths.in.sources.replace(/\\/g, '/');
+    paths.out.file = (opts.useSourceRoot ? paths.out.sources : paths.in.file)
+      .replace(/\\/g, '/');
 
     paths.out.sourceRoot = (
-      es6ifyOpts.sourceRoot ?
+      opts.useSourceRoot ?
       paths.in.sourceRoot :
       path.dirname(paths.in.file) + '/'
     )

--- a/test/transform/traceur-generated-template-parser.js
+++ b/test/transform/traceur-generated-template-parser.js
@@ -1,0 +1,9 @@
+
+        for (var $__placeholder__0 =
+                 $__placeholder__1[
+                     $traceurRuntime.toProperty(Symbol.iterator)](),
+                 $__placeholder__2;
+             !($__placeholder__3 = $__placeholder__4.next()).done; ) {
+          $__placeholder__5;
+          $__placeholder__6;
+        }


### PR DESCRIPTION
This is a work in progress, but I wanted to get the discussion going. It appears to now be necessary to pass a `sourceRoot` param to traceur to get correct paths in source maps. So I think it's time to make the options to `es6ify.configure()` more general or turn this into a plugin. In this pull request I've implemented the former approach, turning the `filePattern` param into `opts` (which can currently take `filePattern` and `sourceRoot` properties). It falls back to the previous behavior if a regex is passed. (I duck typed it based on `ignoreCase` -- cool?) I rearranged some of the internal options passing based on that change and the addition of `sourceRoot` to the mix.
