### PR TITLE
Bump Traceur to version 0.0.90

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://thlorenz.github.io/es6ify/",
   "dependencies": {
     "through": "~2.2.7",
-    "traceur": "0.0.79",
+    "traceur": "0.0.90",
     "xtend": "~2.2.0"
   },
   "devDependencies": {

--- a/test/errors.js
+++ b/test/errors.js
@@ -23,7 +23,7 @@ test('\ncompiling block-scope with blockBinding: false', function (t) {
     .transform(es6ify)
     .require(__dirname + '/../example/src/features/block-scope.js', { entry: true })
     .bundle(function (err, src) {
-      t.similar(err.message, /Unexpected token let/, 'returns error indicating that let is not supported')
+      t.similar(err.message, /Unexpected reserved word let while parsing file/, 'returns error indicating that let is not supported')
       es6ify.traceurOverrides = null;
       t.end();
     });

--- a/test/transform.js
+++ b/test/transform.js
@@ -43,31 +43,20 @@ test('transform adds sourcemap comment and uses cache on second time', function 
 
       // Traceur converts all \s to /s so we need to do so also before comparing
       var fileConverted = file.replace(/\\/g, '/');
-      var sourceRootConverted = path.join(path.dirname(file), path.sep).replace(/\\/g, '/');
 
       t.deepEqual(
           sourceMap
         , { version: 3,
             file: fileConverted,
-            sources: [ fileConverted, '@traceur/generated/TemplateParser/1' ],
+            sources: [ path.basename(fileConverted) ],
             names: [],
             mappings: sourceMap.mappings,
-            sourceRoot: sourceRootConverted,
             sourcesContent: [
               'module.exports = function () {\n' +
               '  for (let element of [1, 2, 3]) {\n' +
               '    console.log(\'element:\', element);\n' +
               '  }\n' +
-              '};\n',
-
-              '\n        for (var $__placeholder__0 =\n' +
-              '                 $__placeholder__1[\n' +
-              '                     $traceurRuntime.toProperty(Symbol.iterator)](),\n' +
-              '                 $__placeholder__2;\n' +
-              '             !($__placeholder__3 = $__placeholder__4.next()).done; ) {\n' +
-              '          $__placeholder__5;\n' +
-              '          $__placeholder__6;\n' +
-              '        }'
+              '};\n'
             ] }
         , 'adds sourcemap comment including original source'
       );


### PR DESCRIPTION
This bumps Traceur to the most recent version (right now 0.0.90).

All tests pass (I had to modify a few, but I ensured that none of that changes removed tests for API features that es6ify used).

I know this has been discussed in #79 and a fix was started in #80. I'm not well versed in es6ify or traceur internals, but the last discussion here was about 0.0.82, so perhaps more API changes have happened that now make es6ify's version bump more seamless.

To confirm that es6ify still works (beyond the safety of the tests), I went into a few of my projects that use es6ify and dropped in this new version. Everything compiled (and the projects still ran in browser).

Of course, I welcome any feedback, if there is an es6ify behavior that I've broken with this PR. I'll try my best to sort it out.

Thanks for maintaining this project! It's really useful to browserify community!
